### PR TITLE
Bugfix/remove autocast symbols

### DIFF
--- a/src/main/js/apps/sample/app.json
+++ b/src/main/js/apps/sample/app.json
@@ -161,7 +161,7 @@
                                 "a": 1
                             },
                             "width": 1,
-                            "type": " esriSLS",
+                            "type": "esriSLS",
                             "style": "solid"
                         }
                     },

--- a/src/main/js/bundles/dn_sketchingenhanced-command/README.md
+++ b/src/main/js/bundles/dn_sketchingenhanced-command/README.md
@@ -61,7 +61,7 @@ Um das Bundle in app.json zu konfigurieren, verwenden Sie die konfigurierbaren, 
           255
         ],
         "width": 2,
-        "type": " esriSLS",
+        "type": "esriSLS",
         "style": "esriSLSSolid"
       }
     },
@@ -115,7 +115,7 @@ Um das Bundle in app.json zu konfigurieren, verwenden Sie die konfigurierbaren, 
           128
         ],
         "width": 1,
-        "type": " esriSLS",
+        "type": "esriSLS",
         "style": "esriSLSSolid"
       }
     },

--- a/src/main/js/bundles/dn_sketchingenhanced-command/manifest.json
+++ b/src/main/js/bundles/dn_sketchingenhanced-command/manifest.json
@@ -120,7 +120,7 @@
                             255
                         ],
                         "width": 2,
-                        "type": " esriSLS",
+                        "type": "esriSLS",
                         "style": "esriSLSSolid"
                     }
                 },
@@ -174,7 +174,7 @@
                             128
                         ],
                         "width": 1,
-                        "type": " esriSLS",
+                        "type": "esriSLS",
                         "style": "esriSLSSolid"
                     }
                 },

--- a/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementController.js
+++ b/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementController.js
@@ -24,7 +24,6 @@ export default class MeasurementController {
 
     activate() {
         this.geoEngine = geoEngine;
-        console.log(i18n.locale);
         this.activeToolType = null;
         this._oldVertex = null;
         this._vertexArray = [];

--- a/src/main/js/bundles/dn_sketchingenhanced-snappingmanager/README.md
+++ b/src/main/js/bundles/dn_sketchingenhanced-snappingmanager/README.md
@@ -35,7 +35,7 @@ Um das Bundle in app.json zu konfigurieren, verwenden Sie die konfigurierbaren, 
                     255
                 ],
                 "width": 1,
-                "type": " esriSLS",
+                "type": "esriSLS",
                 "style": "esriSLSSolid"
             }
         },
@@ -57,7 +57,7 @@ Um das Bundle in app.json zu konfigurieren, verwenden Sie die konfigurierbaren, 
                     255
                 ],
                 "width": 1,
-                "type": " esriSLS",
+                "type": "esriSLS",
                 "style": "esriSLSSolid"
             }
         },

--- a/src/main/js/bundles/dn_sketchingenhanced-snappingmanager/manifest.json
+++ b/src/main/js/bundles/dn_sketchingenhanced-snappingmanager/manifest.json
@@ -47,7 +47,7 @@
                             255
                         ],
                         "width": 1,
-                        "type": " esriSLS",
+                        "type": "esriSLS",
                         "style": "esriSLSSolid"
                     }
                 },
@@ -69,7 +69,7 @@
                             255
                         ],
                         "width": 1,
-                        "type": " esriSLS",
+                        "type": "esriSLS",
                         "style": "esriSLSSolid"
                     }
                 },

--- a/src/main/js/bundles/dn_sketchingenhanced-tools/README.md
+++ b/src/main/js/bundles/dn_sketchingenhanced-tools/README.md
@@ -106,7 +106,7 @@ Um das Bundle in app.json zu konfigurieren, verwenden Sie die konfigurierbaren, 
                   255
                 ],
                 "width": 1,
-                "type": " esriSLS",
+                "type": "esriSLS",
                 "style": "esriSLSSolid"
               }
             },

--- a/src/main/js/bundles/dn_sketchingenhanced-tools/manifest.json
+++ b/src/main/js/bundles/dn_sketchingenhanced-tools/manifest.json
@@ -76,7 +76,7 @@
                                 "a": 1
                             },
                             "width": 1,
-                            "type": " esriSLS",
+                            "type": "esriSLS",
                             "style": "solid"
                         }
                     },

--- a/src/main/js/bundles/dn_sketchingenhanced/components/editors/PointEditor.vue
+++ b/src/main/js/bundles/dn_sketchingenhanced/components/editors/PointEditor.vue
@@ -47,7 +47,6 @@
                     return this.settings.color;
                 },
                 set(val) {
-                    console.log(this.i18n)
                     if(val && val.rgba) {
                         const settings = this.settings;
                         settings.color = val.rgba;

--- a/src/main/js/bundles/dn_sketchingenhanced/manifest.json
+++ b/src/main/js/bundles/dn_sketchingenhanced/manifest.json
@@ -310,7 +310,7 @@
                             255
                         ],
                         "width": 1,
-                        "type": " esriSLS",
+                        "type": "esriSLS",
                         "style": "esriSLSSolid"
                     }
                 },


### PR DESCRIPTION
I tried modifying the symbols to the new form:

"esriSLS" to "simple-line" etc.

but then type not supported errors occur.

There was a typo where "esriSLS" was configured " esriSLS" (with a space character) thus causing the old type not found error