### PR TITLE
resolves #69

### DIFF
--- a/src/main/js/bundles/dn_sketchingenhanced-themes-extension/everlasting/styles/dn_sketchingenhanced.less
+++ b/src/main/js/bundles/dn_sketchingenhanced-themes-extension/everlasting/styles/dn_sketchingenhanced.less
@@ -96,39 +96,40 @@
                                 font-size: 0.9em;
                             }
                             &.v-navigation-drawer {
+                                background-color: darken(@container-background-color,10%);
                                 max-width: 230px;
                                 top: 49px;
                                 position: absolute;
                                 height: calc(100% - 92px)!important;
-                                background-color: darken(@container-background-color,10%);
-                                .v-list__group__header:hover {
-                                    background: darken(@ct-highlight-color,10%);
-                                    color: @ct-highlight-text-color;
-                                    i {
+                                .v-list {
+                                    .v-list__group__header:hover {
+                                        background: darken(@ct-highlight-color,10%);
                                         color: @ct-highlight-text-color;
-                                    }
+                                        i {
+                                            color: @ct-highlight-text-color;
+                                        }
 
-                                }
-                                a:hover {
-                                    background: darken(@ct-highlight-color,10%);
-                                    color: @ct-highlight-text-color;
-                                    i {
-                                        color: @ct-highlight-text-color;
                                     }
-                                }
-                                .highlightedToolParent {
-                                    background-color: darken(@ct-highlight-color,10%);
-                                    color: @ct-highlight-text-color;
-                                    i {
+                                    a:hover {
+                                        background: darken(@ct-highlight-color,10%);
                                         color: @ct-highlight-text-color;
+                                        i {
+                                            color: @ct-highlight-text-color;
+                                        }
                                     }
-                                }
-
-                                .highlightedTool {
-                                    background-color: @ct-highlight-color;
-                                    color: @ct-highlight-text-color;
-                                    i {
+                                    .highlightedToolParent {
+                                        background-color: darken(@ct-highlight-color,10%);
                                         color: @ct-highlight-text-color;
+                                        i {
+                                            color: @ct-highlight-text-color;
+                                        }
+                                    }
+                                    .highlightedTool {
+                                        background-color: @ct-highlight-color;
+                                        color: @ct-highlight-text-color;
+                                        i {
+                                            color: @ct-highlight-text-color;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Group icons can still appear active when collapsed.
![image](https://user-images.githubusercontent.com/69298410/110497553-d774d380-80f6-11eb-833f-31f24bba436f.png)

selecting a non-group tool will deactivate other tools