### PR TITLE
Bugfix#86

### DIFF
--- a/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementController.js
+++ b/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementController.js
@@ -280,20 +280,24 @@ export default class MeasurementHandler {
             text: lengthString,
             flag: "measurementText",
             color: this._model.textSettings.color,
-            name: `measurement-${id}`,
+            id: `measurement-${id}`,
             font: this._model.textSettings.font,
             haloColor: this._model.textSettings.haloColor,
             haloSize: this._model.textSettings.haloSize,
             temporary: this._model.cursorUpdate
         });
-        return new Graphic(pnt, textSymbol);
+        const graphic = new Graphic(pnt, textSymbol);
+        graphic.setAttribute("id",`measurement-${id}`);
+        graphic.setAttribute("type",graphic.symbol.type);
+        return graphic;
     }
 
-    removeGraphicsByName(id) {
+    removeGraphicsById(id) {
         const gs = this.viewModel.layer.graphics.items.filter(graphic => {
-            if (graphic.symbol){
-                // return graphic.symbol.name === `measurement-${id}` && graphic.symbol.temporary
-                return graphic.symbol.name === `measurement-${id}`
+            const type = graphic.getAttribute("type");
+            const textGraphicId = graphic.getAttribute("id");
+            if (textGraphicId) {
+                return textGraphicId === id && type && type === "text";
             }
         });
         this.viewModel.layer.removeMany(gs);

--- a/src/main/js/bundles/dn_sketchingenhanced-measurement/actions/PolygonMeasurementAction.js
+++ b/src/main/js/bundles/dn_sketchingenhanced-measurement/actions/PolygonMeasurementAction.js
@@ -53,6 +53,8 @@ export default class PolygonMeasurementAction {
     }
 
     _updateMeasurements(evt){
+        const update = evt.type === 'update' || evt.type === 'undo';
+        this.isDrawpolygontool = update && evt.graphics[0].geometry.rings;
         this._addPolygonLineMeasurements(evt);
         this._calculatePolygonMeasurements(evt);
     }


### PR DESCRIPTION
when graphics are loaded via sdi_savestate, the graphics are drawn with ids that are unknown to the sketching bundle. Now the graphics include an id attribute which is shipped with the savestate, which can then be used to modify savestate graphics.

This also fixes issue #85