### PR TITLE
Minor fix to destroy the textbox when deactivating tools bundle

### DIFF
--- a/src/main/js/bundles/dn_sketchingenhanced-tools/DrawTextController.js
+++ b/src/main/js/bundles/dn_sketchingenhanced-tools/DrawTextController.js
@@ -37,7 +37,7 @@ export default class DrawTextController extends Connect {
     }
 
     deactivate() {
-        this.deactivateDrawText();
+        this._destroyTextBox();
     }
 
     handler(evt) {


### PR DESCRIPTION
Hi, currently when stopping the dn_sketchingenhanced-tools bundle an exception is raised. This commit should fix this by calling the function to destroy the textbox properly.