### PR TITLE
Fix Issue: Messungen werden beim Abbrechen einer Zeichnung nicht gelö…

### DIFF
--- a/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementHandler.js
+++ b/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementHandler.js
@@ -21,7 +21,7 @@ import { MeasurementLayer } from "./MeasurementLayer";
 import { MeasurementLabelProvider } from "./labels/MeasurementLabelProvider";
 
 export default class MeasurementHandler {
-    
+
     currentAction = [];
 
     activate(context) {
@@ -40,7 +40,7 @@ export default class MeasurementHandler {
         this._model.enableAngleMeasurement = props.enableAngleMeasurement;
 
         this._measurementDisabledTools = props.disabledMeasurementTools;
-        
+
         // set viewModel if SketchingHandler was started before this component
         if (this.sketchingHandler?.sketchViewModel) {
             this._setSketchViewModel(new TopicEvent('must_not_be_empty', { viewModel: this.sketchingHandler.sketchViewModel }));
@@ -116,7 +116,9 @@ export default class MeasurementHandler {
                     break;
                 case 'cancel':
                     this.resetMeasurementResults();
-                    evt.graphic && this.removeGraphicsById(evt.graphic.getAttribute("id"));
+                    this._setGraphics(evt)
+                    this._handleRemove(evt)
+                    // evt.graphic && this.removeGraphicsById(evt.graphic.getAttribute("id"));
                     break
                 case 'complete':
                     this._recordMeasurements(evt);
@@ -126,7 +128,7 @@ export default class MeasurementHandler {
         }
     }
 
-    
+
 
     removeTemporaryMeasurements(evt) {
         const update = evt.type === 'update' || evt.type === 'undo' || evt.type === 'redo';
@@ -245,6 +247,13 @@ export default class MeasurementHandler {
         return Promise.all(callbacks);
     }
 
+    _setGraphics(evt){
+        if(!evt.graphics && evt.graphic){
+            evt.graphics = []
+            evt.graphics[0] = evt.graphic
+        }
+    }
+
     _handleRemove(evt) {
         if (!evt.graphics) return;
         const id = evt.graphics[0].attributes?.id || evt.graphics[0].symbol.id;
@@ -278,7 +287,7 @@ export default class MeasurementHandler {
                 this.setActiveToolType(this._model.activeTool);
             }
         });
-        
+
         const labelProvider = new MeasurementLabelProvider(this._properties?.measurementLabels, this.i18n);
         this._measurementActions.push(new PointAction(this._model, this.layer, this.controller.calculator));
         this._measurementActions.push(new PolylineAction(this.layer, this.controller.calculator, labelProvider, this.controller.angleCalculator));


### PR DESCRIPTION
Issue: Messungen werden beim Abbrechen einer Zeichnung nicht gelöscht #153

evt.graphics[0] is not set for temporal created lines, so _handleRemove did nothing.
Seeting evt.graphics[0] before the methode call, fixes the issue :) 