### PR TITLE
Fehlender Eintrag in der module.js

### DIFF
--- a/src/main/js/bundles/dn_sketchingenhanced/module.js
+++ b/src/main/js/bundles/dn_sketchingenhanced/module.js
@@ -19,3 +19,4 @@ import './DrawTextHelpLine';
 import './BindingToolsToViewModel';
 import './HighlightHandler';
 import './LayerOrderer';
+import './SketchingEnhancedModel';


### PR DESCRIPTION
Der fehlende Eintrag führt dazu, dass bei Standalone-Apps das SketchingEnhancedModel nicht mit exportiert wird und so das Bundle nicht geladen werden kann.