### PR TITLE
Fix typo in tooltip

### DIFF
--- a/src/main/js/bundles/dn_sketchingenhanced/nls/de/bundle.js
+++ b/src/main/js/bundles/dn_sketchingenhanced/nls/de/bundle.js
@@ -61,9 +61,9 @@ export default {
             snappingSelfEnabled: "Geometrieführungslinien",
             snappingFeatureEnabled: "Karteninhalte fangen",
             snappingFeatureSources: "Fang-Inhalte",
-            isNotVisibleInHierarchyAndScale: "Dieser Layer ist im aktuellen Mapstab nicht sichtbar und im TOC deaktiviert.",
+            isNotVisibleInHierarchyAndScale: "Dieser Layer ist im aktuellen Maßstab nicht sichtbar und im TOC deaktiviert.",
             isNotVisibleInHierarchy: "Dieser Layer ist deaktiviert.",
-            isNotVisibleInScale: "Dieser Layer ist im aktuellen Mapstab nicht sichtbar."
+            isNotVisibleInScale: "Dieser Layer ist im aktuellen Maßstab nicht sichtbar."
         },
         symbolSettings: {
             pointSymbolStyle: "Stil",


### PR DESCRIPTION
Change "Mapstab" to "Maßstab" in german translation