### PR TITLE
Fix measurment after changing srs

### DIFF
--- a/src/main/js/apps/sample/app.json
+++ b/src/main/js/apps/sample/app.json
@@ -38,7 +38,9 @@
             "dn_imprintprivacy",
             "dn_sketchingenhanced",
             "dn_sketchingenhanced-measurement",
-            "dn_sketchingenhanced-construction"
+            "dn_sketchingenhanced-construction",
+            "sdi_srschanger",
+            "console"
         ],
         "i18n": [
             "bundle"
@@ -227,6 +229,24 @@
             "Config": {
                 "radius": 10000,
                 "length": 10000
+            }
+        },
+        "sdi_srschanger": {
+             "Config": {
+                 "srsList": [
+                    3857,
+                    4326
+                ]
+             }
+        },
+        "templates": {
+            "TemplateModel": {
+                "widgets": [
+                    {
+                        "widgetRole": "sdi_srschanger",
+                        "attachTo": "footer_right"
+                    }
+                ]
             }
         },
         "agssearch": {
@@ -645,6 +665,7 @@
                     {
                         "id": "mapview_tools",
                         "tools": [
+                            "sketchingEnhancedWidgetToggleTool",
                             "locateMeTool",
                             "zoomInTool",
                             "zoomOutTool",

--- a/src/main/js/apps/sample/app.json
+++ b/src/main/js/apps/sample/app.json
@@ -38,9 +38,7 @@
             "dn_imprintprivacy",
             "dn_sketchingenhanced",
             "dn_sketchingenhanced-measurement",
-            "dn_sketchingenhanced-construction",
-            "sdi_srschanger",
-            "console"
+            "dn_sketchingenhanced-construction"
         ],
         "i18n": [
             "bundle"
@@ -229,24 +227,6 @@
             "Config": {
                 "radius": 10000,
                 "length": 10000
-            }
-        },
-        "sdi_srschanger": {
-             "Config": {
-                 "srsList": [
-                    3857,
-                    4326
-                ]
-             }
-        },
-        "templates": {
-            "TemplateModel": {
-                "widgets": [
-                    {
-                        "widgetRole": "sdi_srschanger",
-                        "attachTo": "footer_right"
-                    }
-                ]
             }
         },
         "agssearch": {

--- a/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementController.ts
+++ b/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementController.ts
@@ -105,13 +105,15 @@ export default class MeasurementController {
         }));
 
         sketchViewModelObservers.add(sketchViewModel.on("update", (event) => {
-            event.graphics.forEach((graphic) => {
-                const uid = graphic.attributes?.uid;
-                uid && this.deleteMeasurementGraphics(uid);
-            });
-            if (!this._sketchingEnhancedModel.deleteClicked) {
-                this.drawMeasurementGraphics(event);
-                this.getMeasurmentCalculations(event);
+            if (this._sketchingEnhancedModel?.activeUi){
+                event.graphics.forEach((graphic) => {
+                    const uid = graphic.attributes?.uid;
+                    uid && this.deleteMeasurementGraphics(uid);
+                });
+                if (!this._sketchingEnhancedModel.deleteClicked) {
+                    this.drawMeasurementGraphics(event);
+                    this.getMeasurmentCalculations(event);
+                }
             }
         }));
     }
@@ -185,7 +187,7 @@ export default class MeasurementController {
 
                 const textGraphic = await graphicsFactory.getPointCoordinatesGraphic(point);
                 tempGraphics.push(textGraphic);
-                this.addTempGraphics(tempGraphics);
+                await this.addTempGraphics(tempGraphics);
             }
             if (activeUi === "polyline") {
                 const polyline = graphic.geometry as __esri.Polyline;
@@ -216,7 +218,7 @@ export default class MeasurementController {
                         }
                     }
                 }
-                this.addTempGraphics(tempGraphics);
+                await this.addTempGraphics(tempGraphics);
             }
             if (activeUi === "polygon") {
                 const polygon = graphic.geometry as __esri.Polygon;
@@ -260,7 +262,7 @@ export default class MeasurementController {
                         }
                     }
                 }
-                this.addTempGraphics(tempGraphics);
+                await this.addTempGraphics(tempGraphics);
             }
 
             if (event.state === "complete") {
@@ -269,11 +271,11 @@ export default class MeasurementController {
                     graphic.setAttribute("uid", graphic.uid);
                 }
                 this.addTempGraphicsToLayer(graphic);
-                this.clearTempGraphics();
+                await this.clearTempGraphics();
             }
 
             if (event.state === "cancel") {
-                this.clearTempGraphics();
+                await this.clearTempGraphics();
             }
         }, 10);
     }
@@ -288,18 +290,16 @@ export default class MeasurementController {
         this.graphicsLayer.addMany(graphics.toArray());
     }
 
-    private addTempGraphics(graphics: Array<__esri.Graphic>): void {
+    private async addTempGraphics(graphics: Array<__esri.Graphic>): Promise<void> {
         graphics = graphics.filter((graphic) => graphic);
-        this.clearTempGraphics();
-        const view = this.sketchViewModel.view;
-        view.graphics.addMany(graphics);
+        await this.clearTempGraphics();
+        (await this.getView()).graphics.addMany(graphics);
         this.tempGraphics.addMany(graphics);
     }
 
-    private clearTempGraphics(): void {
-        const view = this.sketchViewModel.view;
+    private async clearTempGraphics(): Promise<void> {
         const graphics = this.tempGraphics;
-        view.graphics.removeMany(graphics);
+        (await this.getView()).graphics.removeMany(graphics);
         this.tempGraphics.removeAll();
     }
 
@@ -308,5 +308,19 @@ export default class MeasurementController {
         const graphics = sketchViewModel.layer.graphics;
         const graphicsToRemove = graphics.filter((g) => g?.attributes?.parentUid === uid);
         graphics.removeMany(graphicsToRemove);
+    }
+
+    private getView(): Promise<__esri.View> {
+        const sketchViewModel = this.sketchViewModel;
+        return new Promise((resolve) => {
+            if (sketchViewModel.view) {
+                resolve(sketchViewModel.view);
+            } else {
+                const watcher = sketchViewModel.watch("view", (view) => {
+                    watcher.remove();
+                    resolve(view);
+                });
+            }
+        });
     }
 }

--- a/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementGraphicsFactory.ts
+++ b/src/main/js/bundles/dn_sketchingenhanced-measurement/MeasurementGraphicsFactory.ts
@@ -63,11 +63,10 @@ export default class MeasurementController {
     getDistanceLabelBetweenPointsGraphic(point1: __esri.Point, point2: __esri.Point): __esri.Graphic {
         const measurementCalculator = this.measurementCalculator;
         const measurementModel = this.measurementModel;
-        const sketchViewModel = this.sketchViewModel;
         const angle = measurementCalculator.getAngleBetweenTwoPoints(point1, point2);
         const polyline = new Polyline({
             spatialReference: {
-                wkid: sketchViewModel.view.spatialReference.wkid
+                wkid: point1.spatialReference.wkid
             }
         });
         polyline.addPath([point1, point2]);
@@ -156,8 +155,7 @@ export default class MeasurementController {
             return;
         }
         const measurementModel = this.measurementModel;
-        const sketchViewModel = this.sketchViewModel;
-        const currentWKID = sketchViewModel.view.spatialReference.wkid;
+        const currentWKID = center.spatialReference.wkid;
 
         const pointGeometry = {
             type: "point",


### PR DESCRIPTION
Fixes multiple issues with changing the srs (using `sdi_srschanger`) while an edit is in progres and with starting an edit after a srs change.
- Using the correct (old) srs when completing the edit before the change
- Not rerendering the measurments when just starting an edit (because for some reason the active tool is sometimes not set then)

fixes #196